### PR TITLE
Fix object references in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ import * as toi from "@toi/toi";
 
 const isObject = toi
   .required() // make toi reject null or undefined
-  .and(toi.object.is()) // forces that the value is an object
+  .and(toi.obj.is()) // forces that the value is an object
   .and(
-    toi.object.keys({
+    toi.obj.keys({
       num: toi.required().and(toi.num.is()),
       str: toi.required().and(toi.str.is())
     })


### PR DESCRIPTION
Fixes object references in the readme file by replacing `object` with `obj`.
Example: `toi.object.is()` to `toi.obj.is()`